### PR TITLE
feat: Claude Code ワークフローにallowed_tools設定を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,4 +34,9 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: |
+            mcp__github_file_ops__commit_files
+            mcp__github_file_ops__delete_files
+            mcp__github_file_ops__update_claude_comment
+            Bash(npm install)
 


### PR DESCRIPTION
## 概要
Claude Code ワークフローに `allowed_tools` 設定を追加したよ♪

## 変更内容
- GitHubファイル操作ツールの追加 (`mcp__github_file_ops__commit_files`, `mcp__github_file_ops__delete_files`, `mcp__github_file_ops__update_claude_comment`)
- npm installコマンド実行権限の追加 (`Bash(npm install)`)

これでClaudeがより便利に使えるようになるじゃん☆

## テスト計画
- [ ] ワークフローの構文チェック
- [ ] 実際のPRでClaudeの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)