### PR TITLE
fix: allowed_toolsをカンマ区切り形式に修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,9 +34,5 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_tools: |
-            mcp__github_file_ops__commit_files
-            mcp__github_file_ops__delete_files
-            mcp__github_file_ops__update_claude_comment
-            Bash(npm install)
+          allowed_tools: "mcp__github_file_ops__commit_files,mcp__github_file_ops__delete_files,mcp__github_file_ops__update_claude_comment,Bash(npm install)"
 


### PR DESCRIPTION
## Summary
- Claude Code Action の allowed_tools 設定をYAML縦棒形式からカンマ区切り文字列形式に修正したよ♪
- 公式仕様に準拠するための重要な修正じゃん！

## 変更内容
- `.github/workflows/claude.yml` の `allowed_tools` 設定を修正
- YAML縦棒形式 → カンマ区切り文字列形式に変更

## Test plan
- [ ] ワークフローファイルの構文が正しいことを確認
- [ ] Claude Code Actionが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)